### PR TITLE
Fix dead links in documentation

### DIFF
--- a/zk/README.md
+++ b/zk/README.md
@@ -72,7 +72,7 @@ cargo run --release --bin vkey
 
 ## Using the Prover Network
 
-We highly recommend using the Succinct prover network for any non-trivial programs or benchmarking purposes. For more information, see the [setup guide](https://docs.succinct.xyz/prover-network/setup.html).
+We highly recommend using the Succinct prover network for any non-trivial programs or benchmarking purposes. For more information, see the [setup guide](https://docs.succinct.xyz/docs/sp1/prover-network/intro).
 
 To get started, copy the example environment file:
 


### PR DESCRIPTION

- Fixed broken documentation links in `zk/README.md`

## Details
- **Before:** `https://docs.succinct.xyz/prover-network/setup.html` (404)
- **After:** `https://docs.succinct.xyz/docs/sp1/prover-network/intro` (✅ working)

